### PR TITLE
fix: Fix environment variable loading strategy conflict issues

### DIFF
--- a/app.py
+++ b/app.py
@@ -133,7 +133,7 @@ def save_config():
         set_key(dotenv_path, 'ENABLE_TOKEN', str(enable_token).lower())
         
         # 重新加载环境变量
-        load_dotenv()
+        load_dotenv(env_path, override=True)
         
         # 重启代理进程
         if proxy_process:


### PR DESCRIPTION
Added the override=True parameter during environment variables loading to force the .env file configurations to override system environment variables. This fix resolves the issue where configurations cannot be loaded correctly when there are variables with the same name in the system environment, ensuring the application always uses the expected configurations defined in the .env file in the project directory.